### PR TITLE
Make Tokio and async-std modules public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@ mod error;
 mod ffi;
 
 #[cfg(feature = "tokio")]
-mod a_tokio;
+pub mod a_tokio;
 
 #[cfg(feature = "async-std")]
-mod a_std;
+pub mod a_std;
 
 pub use crate::error::*;
 use crate::ffi::*;


### PR DESCRIPTION
Hey, I was interested in using this library for a project, but I noticed that the crates.io version is 0.2 and when I tried the source version, the Tokio module wasn't public so I couldn't use it.

This PR updates the code to make the modules public, would you also be up for releasing a new version to crates.io.