### PR TITLE
Bring codebase to up to date standards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["natpmp", "rfc6886", "nat", "portmapping"]
 categories = ["network-programming"]
 license = "MIT"
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,32 @@ edition = "2018"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[[example]]
+name = "tcp-mapping"
+path = "examples/tcp_mapping.rs"
+
+[[example]]
+name = "udp-mapping"
+path = "examples/udp_mapping.rs"
+
+[[example]]
+name = "async-udp-tokio"
+path = "examples/async_udp_tokio.rs"
+required-features = ["tokio"]
+
+[[example]]
+name = "async-udp-async-std"
+path = "examples/async_udp_asyncstd.rs"
+required-features = ["async-std"]
+
+
 [features]
 default = ["tokio"]
+
 all = ["tokio", "async-std"]
+
+tokio = ["dep:tokio"]
+async-std = ["dep:async-std"]
 
 [build-dependencies]
 cc = "1"      # compile native c

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate cc;
-
 fn main() {
     cc::Build::new()
         .file("src/getgateway.c")

--- a/examples/async_udp_asyncstd.rs
+++ b/examples/async_udp_asyncstd.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use natpmp::*;
 use std::time::Duration;
 
-#[cfg(feature = "async-std")]
 fn main() -> Result<()> {
     use async_std::future;
     use async_std::task;

--- a/examples/async_udp_tokio.rs
+++ b/examples/async_udp_tokio.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use natpmp::*;
 use std::time::Duration;
 
-#[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() -> Result<()> {
     let n = Arc::new(new_tokio_natpmp().await?);


### PR DESCRIPTION
This PR is built on top of #3, which should be merged first, otherwise the diff for this PR will contain the diff of #3 

This PR:

- Adds `required-features` to the examples so that they don't fail to compile with no features
- Removes the now unnecessary feature flag in the examples (this is now done thanks to the `required-features`)
- Bump the `edition` to 2021
- Fix all clippy warnings.
- Remove the unnecessary `extern crate cc` since we are now using edition 2021