### PR TITLE
Remove the `unsafe` extern statics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["natpmp", "rfc6886", "nat", "portmapping"]
 categories = ["network-programming"]
 license = "MIT"
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,32 @@ edition = "2018"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[[example]]
+name = "tcp-mapping"
+path = "examples/tcp_mapping.rs"
+
+[[example]]
+name = "udp-mapping"
+path = "examples/udp_mapping.rs"
+
+[[example]]
+name = "async-udp-tokio"
+path = "examples/async_udp_tokio.rs"
+required-features = ["tokio"]
+
+[[example]]
+name = "async-udp-async-std"
+path = "examples/async_udp_asyncstd.rs"
+required-features = ["async-std"]
+
+
 [features]
 default = ["tokio"]
+
 all = ["tokio", "async-std"]
+
+tokio = ["dep:tokio"]
+async-std = ["dep:async-std"]
 
 [build-dependencies]
 cc = "1"      # compile native c

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate cc;
-
 fn main() {
     cc::Build::new()
         .file("src/getgateway.c")

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     cc::Build::new()
         .file("src/getgateway.c")
-        .file("src/const.c")
         .include("src/")
         .compile("getgateway");
 }

--- a/examples/async_udp_asyncstd.rs
+++ b/examples/async_udp_asyncstd.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use natpmp::*;
 use std::time::Duration;
 
-#[cfg(feature = "async-std")]
 fn main() -> Result<()> {
     use async_std::future;
     use async_std::task;

--- a/examples/async_udp_tokio.rs
+++ b/examples/async_udp_tokio.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use natpmp::*;
 use std::time::Duration;
 
-#[cfg(feature = "tokio")]
 #[tokio::main]
 async fn main() -> Result<()> {
     let n = Arc::new(new_tokio_natpmp().await?);

--- a/src/const.c
+++ b/src/const.c
@@ -1,4 +1,0 @@
-#include <errno.h>
-
-const int RS_EWOULDBLOCK = EWOULDBLOCK;
-const int RS_ECONNREFUSED = ECONNREFUSED;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4,7 +4,5 @@
 extern "C" {}
 
 extern "C" {
-    pub static RS_EWOULDBLOCK: i32;
-    pub static RS_ECONNREFUSED: i32;
     pub fn getdefaultgateway(addr: *mut u32) -> i32;
 }


### PR DESCRIPTION
Built on top of #4 

This insteads reads the `ErrorKind` from `std` to remove almost all uses of  `unsafe`.