### PR TITLE
Bump netdev version and prepare a 0.5.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:
@@ -54,7 +54,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:
@@ -85,7 +85,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:
@@ -55,7 +55,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:
@@ -86,7 +86,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:
@@ -45,7 +45,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:
@@ -76,7 +76,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       # Rust cache
       - name: Rust cargo cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-rust-cargo
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cc = "1"      # compile native c
 async-trait = "0.1"
 tokio = { version = "1", features = ["net"], optional = true }
 async-std = { version = "1", optional = true }
-netdev = "0.31.0"
+netdev = "0.34.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "natpmp"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["fengyingcai <fengyc.work@gmail.com>"]
 description = "NAT-PMP client library"
 homepage = "https://github.com/fengyc/natpmp"


### PR DESCRIPTION
netdev isn't part of the public API, so minor release  is OK.